### PR TITLE
Openejb java agent information

### DIFF
--- a/ides/intelliJ/README.md
+++ b/ides/intelliJ/README.md
@@ -33,6 +33,9 @@ The run must be configured to specify which Application container must be used. 
 
 Unfortunately, the arquillian plugin does not support automatic enhancement of classes, which is necessary for OpenJPA to make classes persistent. We need to delegate this behaviour to a _java agent_, by specifying its path in the JVM options. The path is relative to the root of your IntelliJ Project.
 
+In this example, we use `openejb-javaagent` ([download link](http://central.maven.org/maven2/org/apache/openejb/openejb-javaagent/4.7.5/openejb-javaagent-4.7.5.jar)) in `j2e/agent` subfolder.
+We then have to set `-javaagent:j2e/agent/openejb-javaagent-4.7.5.jar` as a VM option for TomEE tests launching. See picture below.
+
 <p align="center">
   <img src="https://raw.githubusercontent.com/polytechnice-si/4A_ISA_TheCookieFactory/develop/ides/intelliJ/with_javaagent.png"/>
 </p>


### PR DESCRIPTION
Adds `openejb-javaagent` download link and installation instructions for
running arqullian tests with IntelliJ.

Modified:
* ides/intelliJ/README.md