### PR TITLE
Fix non running integration tests

### DIFF
--- a/j2e/pom.xml
+++ b/j2e/pom.xml
@@ -149,7 +149,7 @@
                     <!-- otherwise openejb embedded and tomee embedded shares the same context and EJBContainer is broken -->
                     <reuseForks>false</reuseForks>
                     <excludes>
-                        <exclude>**/PaymentIntegrationTest.java</exclude>
+                        <exclude>**/*IntegrationTest.java</exclude>
                         <exclude>features/*</exclude>
                     </excludes>
                 </configuration>
@@ -162,10 +162,10 @@
                         <phase>integration-test</phase>
                         <configuration>
                             <excludes>
-                                <exclude>**/*Test.java</exclude>
+                                <exclude>none</exclude>
                             </excludes>
                             <includes>
-                                <include>**/PaymentIntegrationTest.java</include>
+                                <include>**/*IntegrationTest.java</include>
                             </includes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
`integration-test` maven target was running nothing because surefire config was excluding all test files (excluded files take over included files).
Fixed it by putting excluded files to none value.

Also generalized the inclusion of integration test files according to the [IntegrationTesting](https://github.com/polytechnice-si/4A_ISA_TheCookieFactory/blob/develop/chapters/IntegrationTesting.md) explanations.